### PR TITLE
Update checkInputList.R

### DIFF
--- a/R/checkInputList.R
+++ b/R/checkInputList.R
@@ -193,8 +193,7 @@ checkInputList <- function(inputList, mistypes = c("mnr", "mbd", "mir", "mbi")) 
                             {.envvar {valueRecodeU}}",
                             wrap = TRUE)
         } else {
-          # Other use cases are possible; therefore, decided to return TRUE here
-          ret <- TRUE
+          # Other use cases are possible; therefore, decided to not return FALSE here
 
           # List all deviating value codes
           cli_alert_danger("{.field valueRecode} contains other values than

--- a/R/checkInputList.R
+++ b/R/checkInputList.R
@@ -194,7 +194,7 @@ checkInputList <- function(inputList, mistypes = c("mnr", "mbd", "mir", "mbi")) 
                             wrap = TRUE)
         } else {
           # Other use cases are possible; therefore, decided to not return FALSE here
-
+          # ret <- TRUE
           # List all deviating value codes
           cli_alert_danger("{.field valueRecode} contains other values than
                            0, 1, and the mistypes.",

--- a/R/checkInputList.R
+++ b/R/checkInputList.R
@@ -194,7 +194,8 @@ checkInputList <- function(inputList, mistypes = c("mnr", "mbd", "mir", "mbi")) 
                             wrap = TRUE)
         } else {
           # Other use cases are possible; therefore, decided to not return FALSE here
-          # ret <- TRUE
+          # ret <- FALSE
+          # maybe consider checking for user-customized valid codes instead.
           # List all deviating value codes
           cli_alert_danger("{.field valueRecode} contains other values than
                            0, 1, and the mistypes.",

--- a/tests/testthat/_snaps/checkInputList.md
+++ b/tests/testthat/_snaps/checkInputList.md
@@ -2239,7 +2239,7 @@
       i Units with more than one subunit: 1 (`I03`)
       v All units with more than one subunit are defined in unitRecodings sheet.
     Output
-      [1] TRUE
+      [1] FALSE
 
 # identifies other value types than vc and mistypes
 

--- a/tests/testthat/test-checkInputList.R
+++ b/tests/testthat/test-checkInputList.R
@@ -200,7 +200,8 @@ test_that("checks for valueRecodes other than 0, 1, and the mistypes", {
   })
 
   # Changed, as the function could be used for other cases than the intended
-  expect_equal(checkInputList(prepList), TRUE)
+  # back-changed due to issue of KKS -- maybe consider checking for user-customized valid codes instead.
+  expect_equal(checkInputList(prepList), FALSE)
   expect_snapshot(checkInputList(prepList))
 })
 


### PR DESCRIPTION
removed L197 to avoid (incorrect) changes of `ret`

fixes #62 