### PR TITLE
adding item groups to make.pseudo

### DIFF
--- a/man/make.pseudo.Rd
+++ b/man/make.pseudo.Rd
@@ -1,46 +1,43 @@
 \name{make.pseudo}
 \alias{make.pseudo}
-
 \title{Transform ratings from real raters into pseudo ratings}
 \description{Data from large-scale assessments often are rated by
 multiple raters. This function reduces the number of raters by the use
 of ``pseudo raters''.}
 \usage{
-make.pseudo (datLong, idCol, varCol, codCol, valueCol, n.pseudo, randomize.order = TRUE,
-             verbose = FALSE)
+make.pseudo(datLong, idCol, varCol, codCol, valueCol, n.pseudo, item.groups = NULL,
+            randomize.order = TRUE, verbose = FALSE)
 }
-%- maybe also 'usage' for other objects documented here.
 \arguments{
   \item{datLong}{
-%%     ~~Describe \code{file} here~~
 Data set in the longformat, i.e. one row per examinee-variable-rater combination.
 }
   \item{idCol}{
-%%     ~~Describe \code{file} here~~
 Name or column number of the person identifier (ID) variable.
 }
   \item{varCol}{
-%%     ~~Describe \code{file} here~~
 Name or column number of the variable identifier.
 }
   \item{codCol}{
-%%     ~~Describe \code{file} here~~
 Name or column number of the rater identifier variable.
 }
   \item{valueCol}{
-%%     ~~Describe \code{file} here~~
 Name or column number of the value variable.
 }
   \item{n.pseudo}{
-%%     ~~Describe \code{file} here~~
 How many pseudo rater should be used? (value must be lower than the number of real raters)
 }
+  \item{item.groups}{
+Optional: List of linked variables that could later be aggregated into items. If two raters
+make inconsistent judgments, it may be more favorable for aggregation if all variables
+belonging to an item are coded by the same rater per examinee. However, if a rater has not
+rated all the variables of the item, the ratings of other raters are used for the variables
+not rated by this rater.
+}
   \item{randomize.order}{
-%%     ~~Describe \code{file} here~~
 Logical: if TRUE, the selection of raters to pseudo raters is random.
 }
   \item{verbose}{
-%%     ~~Describe \code{file} here~~
 Logical: give information about number of persons, variables, raters?
 }
 }
@@ -53,8 +50,13 @@ Sebastian Weirich
 \examples{
 data(rater)
 oneRater <- make.pseudo (datLong=rater, idCol="id", varCol="variable", codCol="rater",
-            valueCol="value", n.pseudo=1)
+            valueCol="value", n.pseudo=1, verbose=TRUE)
 twoRaters<- make.pseudo (datLong=rater, idCol="id", varCol="variable", codCol="rater",
             valueCol="value", n.pseudo=2)
+# with item groups, allowing that all variables belonging to an item are coded by the
+# same rater (per examinee)
+itemGroup<- list(first = c("V01", "V03"), second = c("V05", "V06", "V07"))
+oneRater2<- make.pseudo (datLong=rater, idCol="id", varCol="variable", codCol="rater",
+            item.groups = itemGroup, valueCol="value", verbose=TRUE, n.pseudo=1)
+attr(oneRater2, "info")
 }
-


### PR DESCRIPTION
This allows variables that are later aggregated into an item to be evaluated by the same coder if required.
I have added a small extension so that the same coder can be selected for paired variables that are later to be aggregated into an item. This allows a higher consistency and a higher N per item if some coders have mistakenly assigned missing values for one or more variables of this item. 