### PR TITLE
Prefer or neglect coders in make.pseudo()

### DIFF
--- a/R/rater_functions.R
+++ b/R/rater_functions.R
@@ -8,7 +8,7 @@ make.pseudo <- function(datLong, idCol, varCol, codCol, alwaysPrefer = NULL, alw
       info   <- NULL                                                            ### initialisieren
       datLong<- eatTools::makeDataFrame(datLong)
       allVars<- list(idCol = idCol, varCol = varCol, codCol = codCol, valueCol=valueCol)
-      allNams<- lapply(allVars, FUN=function(ii) {eatTools::existsBackgroundVariables(dat = datLong, variable=ii)})
+      allNams<- lapply(allVars, FUN=function(ii) {eatTools::existsBackgroundVariables(dat = datLong, variable=ii, warnIfMissing = TRUE,  stopIfMissingOnVars = c(allVars[["idCol"]], allVars[["varCol"]], allVars[["codCol"]]))})
       add    <- setdiff(colnames(datLong), unlist(allNams))
       stopifnot(all(unlist(lapply(list(alwaysPrefer, alwaysNeglect),FUN = function (x) {
            ret <- checkmate::test_character(x, len=1, null.ok = TRUE, any.missing = FALSE) || checkmate::test_numeric(x, len=1, null.ok = TRUE, any.missing = FALSE)

--- a/R/rater_functions.R
+++ b/R/rater_functions.R
@@ -4,14 +4,19 @@
 ### codCol: Nummer oder Name der Kodiererspalte
 ### n.pseudo: wieviele Pseudocodierer?
 ### randomize.order: soll die Reihenfolge der Pseudocodes nach Zufall bestimmt werden?
-make.pseudo <- function(datLong, idCol, varCol, codCol, valueCol, n.pseudo, item.groups = NULL, randomize.order = TRUE, verbose = FALSE)   {
+make.pseudo <- function(datLong, idCol, varCol, codCol, alwaysPrefer = NULL, alwaysNeglect = NULL, valueCol, n.pseudo, item.groups = NULL, randomize.order = TRUE, verbose = FALSE)   {
       info   <- NULL                                                            ### initialisieren
       datLong<- eatTools::makeDataFrame(datLong)
       allVars<- list(idCol = idCol, varCol = varCol, codCol = codCol, valueCol=valueCol)
       allNams<- lapply(allVars, FUN=function(ii) {eatTools::existsBackgroundVariables(dat = datLong, variable=ii)})
       add    <- setdiff(colnames(datLong), unlist(allNams))
+      stopifnot(all(unlist(lapply(list(alwaysPrefer, alwaysNeglect),FUN = function (x) {
+           ret <- checkmate::test_character(x, len=1, null.ok = TRUE, any.missing = FALSE) || checkmate::test_numeric(x, len=1, null.ok = TRUE, any.missing = FALSE)
+           if(!is.null(x)) {if(!x %in% datLong[,allNams[["codCol"]]]) {stop(paste0("Rater with name '",x,"' does not occur in column '",allNams[["codCol"]],"'."))}}
+           return(ret)}))))
       if ( length(add)>0) {if(verbose) {cat(paste0("   Found ",length(add)," additional variables in long format data.frame: '",paste(add, collapse="', '"),"'. If these variable(s) vary between raters (within examinees and items), only the value according to the chosen rater will be kept.\n"))}}
       if(length(allNams) != length(unique(allNams)) ) {stop("'idCol', 'varCol', 'codCol' and 'valueCol' overlap.\n")}
+      if(!is.null(alwaysPrefer) && !is.null(alwaysNeglect)) {stopifnot (alwaysPrefer != alwaysNeglect)}
       if(!is.null(item.groups)) {                                               ### checks
         checkmate::assert_character(unlist(item.groups), unique=TRUE, any.missing = FALSE)
         lapply(item.groups,checkmate::assert_character, min.len = 2)
@@ -38,6 +43,11 @@ make.pseudo <- function(datLong, idCol, varCol, codCol, valueCol, n.pseudo, item
                    datVar <- by(data = datVar, INDICES = datVar[, allNams[["idCol"]]], FUN = function ( sub.dat) {
                              stopifnot(nrow(sub.dat)>n.pseudo)                  ### wenn die Rater mit unterschiedlicher Haeufigkeit geratet haben, soll der haeufigste genommen werden
                              nrat <- table(sub.dat[,allNams[["codCol"]]])       ### wenn der haeufigste weniger als die Haelfte der Codierungen bewertet hat, kann ggf. nicht ein einheitlicher Rater fuer paarweise verbundene Variablen genommen werden
+                             if(!is.null(alwaysPrefer) && alwaysPrefer %in% sub.dat[,allNams[["codCol"]]]) {
+                                nrat <- nrat[which(names(nrat) == alwaysPrefer)]
+                             } else {
+                                if(!is.null(alwaysNeglect) && alwaysNeglect %in% sub.dat[,allNams[["codCol"]]]) {nrat <- nrat[which(names(nrat) != alwaysNeglect)]}
+                             }
                              if(!is.null(item.groups) && max(nrat) < nrow(sub.dat)/2)  {
                                 info    <- rbind(info, data.frame ( variable.bundle = paste(vars, collapse= ", "), examinee = unique(sub.dat[,allNams[["idCol"]]]),stringsAsFactors = FALSE))
                                 auswahl <- do.call("rbind", by(data = sub.dat, INDICES = sub.dat[,allNams[["varCol"]]], FUN = function (sub.var.dat ) {

--- a/man/make.pseudo.Rd
+++ b/man/make.pseudo.Rd
@@ -5,7 +5,8 @@
 multiple raters. This function reduces the number of raters by the use
 of ``pseudo raters''.}
 \usage{
-make.pseudo(datLong, idCol, varCol, codCol, valueCol, n.pseudo, item.groups = NULL,
+make.pseudo(datLong, idCol, varCol, codCol, alwaysPrefer = NULL,
+            alwaysNeglect = NULL, valueCol, n.pseudo, item.groups = NULL,
             randomize.order = TRUE, verbose = FALSE)
 }
 \arguments{
@@ -21,11 +22,18 @@ Name or column number of the variable identifier.
   \item{codCol}{
 Name or column number of the rater identifier variable.
 }
+  \item{alwaysPrefer}{
+Optional: Single name of the rater that should always be preferred if it is part of a double coding.
+}
+  \item{alwaysNeglect}{
+Optional: Single name of the rater that should always be neglected if it is part of a double coding.
+This means that coding by this rater is only taken into account if no other rater has rated this response.
+}
   \item{valueCol}{
 Name or column number of the value variable.
 }
   \item{n.pseudo}{
-How many pseudo rater should be used? (value must be lower than the number of real raters)
+How many pseudo raters should be used? (value must be lower than the number of real raters)
 }
   \item{item.groups}{
 Optional: List of linked variables that could later be aggregated into items. If two raters
@@ -59,4 +67,14 @@ itemGroup<- list(first = c("V01", "V03"), second = c("V05", "V06", "V07"))
 oneRater2<- make.pseudo (datLong=rater, idCol="id", varCol="variable", codCol="rater",
             item.groups = itemGroup, valueCol="value", verbose=TRUE, n.pseudo=1)
 attr(oneRater2, "info")
+# prefer John
+oneRater <- make.pseudo (datLong=rater, idCol="id", varCol="variable", codCol="rater",
+            alwaysPrefer = "John", valueCol="value", n.pseudo=1, verbose=TRUE)
+# neglect Edward
+oneRater <- make.pseudo (datLong=rater, idCol="id", varCol="variable", codCol="rater",
+            alwaysNeglect = "Edward", valueCol="value", n.pseudo=1, verbose=TRUE)
+# prefer Dolores and neglect Edward
+oneRater <- make.pseudo (datLong=rater, idCol="id", varCol="variable", codCol="rater",
+            alwaysPrefer = "Dolores", alwaysNeglect = "Edward", valueCol="value",
+            n.pseudo=1, verbose=TRUE)
 }


### PR DESCRIPTION
If raters work with different levels of reliability, you can select here which should be preferred or ignored in the case of multiple encodings. The preferred one is always taken if it is part of a multiple coding. The neglected one is only taken if no other coder has evaluated this response. 